### PR TITLE
Fix/Netlify Analytics API v1 deprecation & switch to v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ async function start() {
 }
 
 async function getMetric(metric) {
-    const url = `https://analytics.services.netlify.com/v1/${siteId}/${metric}?from=${startDate.getTime().toFixed()}&to=${endDate.getTime()}&timezone=${timezone}&resolution=day`;
+    const url = `https://analytics.services.netlify.com/v2/${siteId}/${metric}?from=${startDate.getTime().toFixed()}&to=${endDate.getTime()}&timezone=${timezone}&resolution=day`;
     try {
         var res = await fetch(url, {
             "credentials": "include",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-analytics-collector",
-  "version": "1.2.0",
+  "version": "1.2.0-api-v2-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netlify-analytics-collector",
-  "version": "1.2.0",
+  "version": "1.2.0-api-v2-rc.1",
   "description": "A simple NodeJs application which saves netlify analytics to a CSV file",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Looks like a super simple fix...for now.
I checked in the network tab of the Netlify dashboard and the requests looked exactly like in `v1` only with the `v1` replaced with `v2`.

Local testing of `index.js` execution with this change seemed to worked, but I'd like to first test the whole workflow of our blog with this.
Can you get a feature package version published for us to test in our blog actions workflow with @NiklasMerz ?
If that works, we should merge this soon